### PR TITLE
Merged ObjectStreamClass.newInstance() with latest Android version

### DIFF
--- a/jre_emul/android/platform/libcore/ojluni/src/main/java/java/io/ObjectStreamClass.java
+++ b/jre_emul/android/platform/libcore/ojluni/src/main/java/java/io/ObjectStreamClass.java
@@ -56,6 +56,11 @@ import sun.reflect.Reflection;
 import sun.reflect.misc.ReflectUtil;
 //import dalvik.system.VMRuntime;
 
+/*-[
+// Thrown by newInstance().
+#include "java/lang/InstantiationException.h"
+]-*/
+
 /**
  * Serialization's descriptor for classes.  It contains the name and
  * serialVersionUID of the class.  The ObjectStreamClass for a specific class
@@ -1006,22 +1011,22 @@ public class ObjectStreamClass implements Serializable {
      * class is non-serializable or if the appropriate no-arg constructor is
      * inaccessible/unavailable.
      */
-    Object newInstance()
-            throws InstantiationException, InvocationTargetException,
-            UnsupportedOperationException
-    {
-        requireInitialized();
-        if (cons != null) {
-            try {
-                return cons.newInstance();
-            } catch (IllegalAccessException ex) {
-                // should not occur, as access checks have been suppressed
-                throw new InternalError(ex);
-            }
-        } else {
-            throw new UnsupportedOperationException();
+    native Object newInstance()
+            throws InstantiationException, UnsupportedOperationException /*-[
+        JavaIoObjectStreamClass_requireInitialized(self);
+        if (cons_ == nil) {
+            @throw create_JavaLangUnsupportedOperationException_init();
         }
-    }
+        SEL sel = [cons_ getSelector];
+        IOSClass *instantiationClass = [cons_ getDeclaringClass];
+        id (*imp)(id, SEL) = (id (*)(id, SEL)) class_getMethodImplementation(
+            instantiationClass.objcClass, sel);
+        id newInstance = [[cl_.objcClass alloc] autorelease];
+        if (newInstance == nil) {
+            @throw create_JavaLangInstantiationException_init();
+        }
+        return imp(newInstance, sel);
+    ]-*/;
 
     /**
      * Invokes the writeObject method of the represented serializable class.


### PR DESCRIPTION
ObjectStreamClass.newInstance() was implemented as native Objective C, because of the difference in how objects are instantiated from Java (creating objects during serialization requires the new instance to use the constructor from the first non-serializable superclass). Since the latest libcore version of ObjectStreamClass had a different implementation of newInstance(), this merged the Objective C instantiation code into the libcore logic.